### PR TITLE
Feature/view food data

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -1,7 +1,13 @@
 import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
+import { ListPageComponent } from './components/pages/list-page/list-page.component';
+import { ViewFoodPageComponent } from './components/pages/view-food-page/view-food-page.component';
 
-const routes: Routes = [];
+const routes: Routes = [
+  { path: 'list', component: ListPageComponent },
+  { path: 'view/:id', component: ViewFoodPageComponent },
+  { path: '',   redirectTo: '/list', pathMatch: 'full' },
+];
 
 @NgModule({
   imports: [RouterModule.forRoot(routes)],

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,14 +1,3 @@
 <app-header></app-header>
-<app-toolbar></app-toolbar>
-<app-food-counter></app-food-counter>
 
-<app-add-popover></app-add-popover>
-
-<button mat-fab class="edit-button">
-  <mat-icon>edit</mat-icon>
-</button>
-
-<div class="tree-wrapper">
-  <app-tree></app-tree>
-</div>
 <router-outlet></router-outlet>

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -1,4 +1,1 @@
-.tree-wrapper {
-  margin-left: 10em;
-  width: fit-content;
-}
+

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -33,6 +33,7 @@ import { SharedTreeDataService } from './services/shared-tree-data.service';
 import { TreeService } from './services/tree.service';
 import { ListPageComponent } from './components/pages/list-page/list-page.component';
 import { ViewFoodPageComponent } from './components/pages/view-food-page/view-food-page.component';
+import { RouterModule } from '@angular/router';
 
 @NgModule({
   declarations: [
@@ -53,6 +54,7 @@ import { ViewFoodPageComponent } from './components/pages/view-food-page/view-fo
   imports: [
     BrowserModule,
     AppRoutingModule,
+    RouterModule,
     BrowserAnimationsModule,
     MatToolbarModule,
     MatButtonModule,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -31,6 +31,8 @@ import { AngularFirestoreModule } from '@angular/fire/firestore';
 import { firebaseConfig } from './credentials';
 import { SharedTreeDataService } from './services/shared-tree-data.service';
 import { TreeService } from './services/tree.service';
+import { ListPageComponent } from './components/pages/list-page/list-page.component';
+import { ViewFoodPageComponent } from './components/pages/view-food-page/view-food-page.component';
 
 @NgModule({
   declarations: [
@@ -45,6 +47,8 @@ import { TreeService } from './services/tree.service';
     TreeComponent,
     TreeNodeExpanderComponent,
     FoodCounterComponent,
+    ListPageComponent,
+    ViewFoodPageComponent,
   ],
   imports: [
     BrowserModule,

--- a/src/app/components/pages/list-page/list-page.component.html
+++ b/src/app/components/pages/list-page/list-page.component.html
@@ -1,0 +1,12 @@
+<app-toolbar></app-toolbar>
+<app-food-counter></app-food-counter>
+
+<app-add-popover></app-add-popover>
+
+<button mat-fab class="edit-button">
+  <mat-icon>edit</mat-icon>
+</button>
+
+<div class="tree-wrapper">
+  <app-tree></app-tree>
+</div>

--- a/src/app/components/pages/list-page/list-page.component.scss
+++ b/src/app/components/pages/list-page/list-page.component.scss
@@ -1,0 +1,4 @@
+.tree-wrapper {
+  margin-left: 10em;
+  width: fit-content;
+}

--- a/src/app/components/pages/list-page/list-page.component.spec.ts
+++ b/src/app/components/pages/list-page/list-page.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ListPageComponent } from './list-page.component';
+
+describe('ListPageComponent', () => {
+  let component: ListPageComponent;
+  let fixture: ComponentFixture<ListPageComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ ListPageComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ListPageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/pages/list-page/list-page.component.ts
+++ b/src/app/components/pages/list-page/list-page.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-list-page',
+  templateUrl: './list-page.component.html',
+  styleUrls: ['./list-page.component.scss']
+})
+export class ListPageComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/src/app/components/pages/view-food-page/view-food-page.component.html
+++ b/src/app/components/pages/view-food-page/view-food-page.component.html
@@ -1,0 +1,1 @@
+<p>view-food-page works!</p>

--- a/src/app/components/pages/view-food-page/view-food-page.component.html
+++ b/src/app/components/pages/view-food-page/view-food-page.component.html
@@ -1,1 +1,5 @@
 <p>view-food-page works!</p>
+<button routerLink="/list">Back to list</button>
+<p *ngIf="!isTreeLoading && !isUndefined">{{node?.id}}</p>
+<p *ngIf="!isTreeLoading && isUndefined">Could not find food with id: {{id}}</p>
+<p *ngIf="isTreeLoading">LOADING</p>

--- a/src/app/components/pages/view-food-page/view-food-page.component.spec.ts
+++ b/src/app/components/pages/view-food-page/view-food-page.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ViewFoodPageComponent } from './view-food-page.component';
+
+describe('ViewFoodPageComponent', () => {
+  let component: ViewFoodPageComponent;
+  let fixture: ComponentFixture<ViewFoodPageComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ ViewFoodPageComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ViewFoodPageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/pages/view-food-page/view-food-page.component.ts
+++ b/src/app/components/pages/view-food-page/view-food-page.component.ts
@@ -1,15 +1,60 @@
 import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { SharedTreeDataService } from 'src/app/services/shared-tree-data.service';
+import { TreeService } from 'src/app/services/tree.service';
+import { Node } from '../../../interfaces/interfaces';
 
 @Component({
   selector: 'app-view-food-page',
   templateUrl: './view-food-page.component.html',
-  styleUrls: ['./view-food-page.component.scss']
+  styleUrls: ['./view-food-page.component.scss'],
 })
 export class ViewFoodPageComponent implements OnInit {
+  nodes: Node[] = [];
+  node: Node;
+  id: string;
+  isUndefined: boolean = false;
+  isTreeLoading: boolean = true;
 
-  constructor() { }
-
-  ngOnInit(): void {
+  constructor(
+    private treeSvc: TreeService,
+    private route: ActivatedRoute,
+    private sharedDataSvc: SharedTreeDataService
+  ) {
+    this.treeSvc.getNodes().subscribe((res) => {
+      this.nodes = res.nodes;
+      this._fallbackData();
+      this.isTreeLoading = this.treeSvc.isLoading;
+    });
   }
 
+  ngOnInit(): void {
+    this._setPageData();
+  }
+
+  /* this.node is undefined, then try to get the data
+    from the shared data that is taken from the DB
+  */
+  private _fallbackData = () => {
+    if (this.node === undefined) {
+      [this.node] = this.nodes.filter((n) => n.id === this.id);
+    }
+
+    // Possibly undefined after filter.
+    this.isUndefined = this.node === undefined;
+  };
+
+  /* When routing to the page, it sets the node data
+    and handles several different cases.
+    Ref: https://stackoverflow.com/a/47382088/9931154
+  */
+  private _setPageData() {
+    this.node = this.sharedDataSvc.node;
+    this.id = this.route.snapshot.paramMap.get('id');
+
+    // Slow fallback if we routed to this page going to the list first
+    if (this.node?.id !== this.id) {
+      this._fallbackData();
+    }
+  }
 }

--- a/src/app/components/pages/view-food-page/view-food-page.component.ts
+++ b/src/app/components/pages/view-food-page/view-food-page.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-view-food-page',
+  templateUrl: './view-food-page.component.html',
+  styleUrls: ['./view-food-page.component.scss']
+})
+export class ViewFoodPageComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/src/app/components/tree/tree.component.html
+++ b/src/app/components/tree/tree.component.html
@@ -17,6 +17,7 @@
         [treeDrag]="node"
         [treeDragEnabled]="node.allowDrag()">
 
+        <!-- Update this is you want to override what each node is displayed as -->
         <tree-node-content [node]="node" [index]="index"></tree-node-content>
       </div>
     </div>

--- a/src/app/components/tree/tree.component.ts
+++ b/src/app/components/tree/tree.component.ts
@@ -1,8 +1,11 @@
 import { Component, OnInit, ViewChild } from '@angular/core';
+import { Router } from '@angular/router';
+import { IActionMapping } from '@circlon/angular-tree-component';
 import { SharedTreeDataService } from 'src/app/services/shared-tree-data.service';
 import { TreeService } from 'src/app/services/tree.service';
 import { Node, Tree } from '../../interfaces/interfaces';
 
+// References: https://stackoverflow.com/a/41427647/9931154
 @Component({
   selector: 'app-tree',
   templateUrl: './tree.component.html',
@@ -13,17 +16,27 @@ export class TreeComponent implements OnInit {
   // get handle an tree template variable
   @ViewChild('myCoolTree') tree: Tree;
 
+  actionMapping: IActionMapping = {
+    mouse: {
+      click: (tree, node, $event) => {
+        this.router.navigateByUrl(`/view/${node.id}`)
+      },
+    },
+  };
+
   treeOptions = {
     allowDrag: true,
     allowDrop: true,
     animateExpand: true,
     animateSpeed: 5,
     animateAcceleration: 1.3,
+    actionMapping: this.actionMapping,
   };
 
   constructor(
     private treeSvc: TreeService,
-    private sharedDataSvc: SharedTreeDataService
+    private sharedDataSvc: SharedTreeDataService,
+    private router: Router,
   ) {
     this.treeSvc.getNodes().subscribe((res) => {
       this.nodes = res.nodes;

--- a/src/app/components/tree/tree.component.ts
+++ b/src/app/components/tree/tree.component.ts
@@ -13,13 +13,16 @@ import { Node, Tree } from '../../interfaces/interfaces';
 })
 export class TreeComponent implements OnInit {
   nodes: Node[] = [];
+  clickedNode: Node;
   // get handle an tree template variable
   @ViewChild('myCoolTree') tree: Tree;
 
+  /* Provide custom callbacks */
   actionMapping: IActionMapping = {
     mouse: {
       click: (tree, node, $event) => {
-        this.router.navigateByUrl(`/view/${node.id}`)
+        this.clickedNode = node;
+        this.router.navigateByUrl(`/view/${node.id}`);
       },
     },
   };
@@ -43,9 +46,13 @@ export class TreeComponent implements OnInit {
     });
   }
 
-  ngOnInit(): void {}
-
-  ngAfterViewInit(): void {
+  ngOnInit(): void {
     this.sharedDataSvc.tree = this.tree;
+
+  }
+
+  // ref: https://stackoverflow.com/a/39569933/9931154
+  ngOnDestroy(): void {
+    this.sharedDataSvc.node = this.clickedNode;
   }
 }

--- a/src/app/services/shared-tree-data.service.ts
+++ b/src/app/services/shared-tree-data.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { Tree } from '../interfaces/interfaces';
+import { Node, Tree } from '../interfaces/interfaces';
 
 @Injectable({
   providedIn: 'root',
@@ -8,12 +8,21 @@ export class SharedTreeDataService {
   constructor() {}
 
   private _tree: Tree;
+  private _node: Node;
 
-  set tree(treeData: Tree) {
-    this._tree = treeData;
+  set tree(tree: Tree) {
+    this._tree = tree;
   }
 
   get tree() {
     return this._tree;
+  }
+
+  set node(node: Node) {
+    this._node = node
+  }
+
+  get node() {
+    return this._node;
   }
 }

--- a/src/app/services/tree.service.ts
+++ b/src/app/services/tree.service.ts
@@ -11,6 +11,7 @@ const userName = 'user1';
 })
 export class TreeService {
   nodes: Node[];
+  isLoading: boolean = true;
 
   constructor(private db: AngularFirestore) {
     this.getNodes().subscribe((res) => {
@@ -51,7 +52,9 @@ export class TreeService {
   }
 
   getUserDoc = () => {
-    return this.db.collection('users').doc<{ nodes: Node[] }>(userName);
+    const userDoc = this.db.collection('users').doc<{ nodes: Node[] }>(userName);
+    this.isLoading = false;
+    return userDoc;
   };
 
   /* Returns an observable of the node tree */


### PR DESCRIPTION
This PR adds the ability to route to a view-food page and back to the main list page. There is no styling yet, but in the future, it would be good to add Material components. 

Test by clicking on a list node and then routing back. 

This handles edge cases to get data in multiple ways.