### PR TITLE
Feature/add tags

### DIFF
--- a/src/app/components/add-food-tab/add-food-tab.component.html
+++ b/src/app/components/add-food-tab/add-food-tab.component.html
@@ -6,6 +6,7 @@
   <app-multiple-autocomplete
     placeholder="Tags"
     width="100%"
+    [tagsOnly]="true"
     (values)="onTagsChange($event)"
   ></app-multiple-autocomplete>
   <mat-form-field class="form-field">

--- a/src/app/components/add-food-tab/add-food-tab.component.html
+++ b/src/app/components/add-food-tab/add-food-tab.component.html
@@ -1,4 +1,4 @@
-<form #f="ngForm" (ngSubmit)="onSubmit()">
+<form #f="ngForm" (ngSubmit)="onSubmit()" class="form">
   <mat-form-field class="form-field">
     <mat-label>Name</mat-label>
     <input matInput [(ngModel)]="node.name" required name="name" />

--- a/src/app/components/add-food-tab/add-food-tab.component.html
+++ b/src/app/components/add-food-tab/add-food-tab.component.html
@@ -7,7 +7,6 @@
     placeholder="Tags"
     width="100%"
     (values)="onTagsChange($event)"
-    [separatorKeysCodes]="[]"
   ></app-multiple-autocomplete>
   <mat-form-field class="form-field">
     <mat-label>Location</mat-label>

--- a/src/app/components/add-food-tab/add-food-tab.component.ts
+++ b/src/app/components/add-food-tab/add-food-tab.component.ts
@@ -1,7 +1,7 @@
 import { Component, EventEmitter, Output, ViewChild } from '@angular/core';
 import { TreeService } from 'src/app/services/tree.service';
-import { Node } from '../../interfaces/interfaces';
-import { pickBy, identity } from 'lodash';
+import { Node } from 'src/app/interfaces/interfaces';
+import { pickBy, identity, forEach } from 'lodash';
 import { v4 } from 'uuid';
 import { MultipleAutocompleteComponent } from '../multiple-autocomplete/multiple-autocomplete.component';
 
@@ -12,7 +12,6 @@ import { MultipleAutocompleteComponent } from '../multiple-autocomplete/multiple
 })
 export class AddFoodTabComponent {
   node: Node = {
-    id: '',
     name: '',
     location: undefined,
     date: undefined,
@@ -37,9 +36,16 @@ export class AddFoodTabComponent {
     this.node.rating = this.currentRate;
     // Remove all falsy values
     this.node = pickBy(this.node, identity);
+
+    // Add tags that haven't already been added
+    forEach(this.node.tags, (tag) => {
+      if (!this.treeSvc.hasTag(tag)) {
+        this.treeSvc.addNode({ id: v4(), name: tag, isTag: true });
+      }
+    });
+
     this.treeSvc.addNode(this.node);
     this.node = {
-      id: '',
       name: '',
       location: undefined,
       date: undefined,

--- a/src/app/components/add-popover/add-popover.component.html
+++ b/src/app/components/add-popover/add-popover.component.html
@@ -19,7 +19,7 @@
         <app-add-food-tab (submitted)="closePopover()"></app-add-food-tab>
       </mat-tab>
       <mat-tab label="Tag">
-        <app-add-tag-tab></app-add-tag-tab>
+        <app-add-tag-tab (submitted)="closePopover()"></app-add-tag-tab>
       </mat-tab>
     </mat-tab-group>
   </mat-card>

--- a/src/app/components/add-tag-tab/add-tag-tab.component.html
+++ b/src/app/components/add-tag-tab/add-tag-tab.component.html
@@ -1,4 +1,4 @@
-<form #f="ngForm" (ngSubmit)="onSubmit()">
+<form #f="ngForm" (ngSubmit)="onSubmit()" class="form">
   <mat-form-field class="form-field">
     <mat-label>Name</mat-label>
     <input matInput [(ngModel)]="node.name" required name="name" />

--- a/src/app/components/add-tag-tab/add-tag-tab.component.html
+++ b/src/app/components/add-tag-tab/add-tag-tab.component.html
@@ -1,10 +1,13 @@
-<mat-form-field class="form-field">
-  <mat-label>Name</mat-label>
-  <input matInput />
-</mat-form-field>
-<app-multiple-autocomplete
-  placeholder="Parent Tags"
-  width="100%"
-  [separatorKeysCodes]="[]"
-></app-multiple-autocomplete>
-<button mat-raised-button color="primary">Submit</button>
+<form #f="ngForm" (ngSubmit)="onSubmit()">
+  <mat-form-field class="form-field">
+    <mat-label>Name</mat-label>
+    <input matInput [(ngModel)]="node.name" required name="name" />
+  </mat-form-field>
+  <app-multiple-autocomplete
+    placeholder="Parent Tags"
+    width="100%"
+    [separatorKeysCodes]="[]"
+    (values)="onTagsChange($event)"
+  ></app-multiple-autocomplete>
+  <button mat-raised-button color="primary" type="submit">Submit</button>
+</form>

--- a/src/app/components/add-tag-tab/add-tag-tab.component.html
+++ b/src/app/components/add-tag-tab/add-tag-tab.component.html
@@ -7,6 +7,7 @@
     placeholder="Parent Tags"
     width="100%"
     [separatorKeysCodes]="[]"
+    [tagsOnly]="true"
     (values)="onTagsChange($event)"
   ></app-multiple-autocomplete>
   <button mat-raised-button color="primary" type="submit">Submit</button>

--- a/src/app/components/add-tag-tab/add-tag-tab.component.ts
+++ b/src/app/components/add-tag-tab/add-tag-tab.component.ts
@@ -1,15 +1,37 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, EventEmitter, Output, ViewChild } from '@angular/core';
+import { Node } from 'src/app/interfaces/interfaces';
+import { TreeService } from 'src/app/services/tree.service';
+import { v4 } from 'uuid';
+import { MultipleAutocompleteComponent } from '../multiple-autocomplete/multiple-autocomplete.component';
 
 @Component({
   selector: 'app-add-tag-tab',
   templateUrl: './add-tag-tab.component.html',
-  styleUrls: ['./add-tag-tab.component.scss']
+  styleUrls: ['./add-tag-tab.component.scss'],
 })
-export class AddTagTabComponent implements OnInit {
+export class AddTagTabComponent {
+  node: Node = {
+    name: '',
+    isTag: true,
+  };
+  @Output() submitted: EventEmitter<boolean> = new EventEmitter();
+  @ViewChild(MultipleAutocompleteComponent)
+  tagsComponent: MultipleAutocompleteComponent;
 
-  constructor() { }
+  constructor(private treeSvc: TreeService) {}
 
-  ngOnInit(): void {
-  }
+  onTagsChange = (tags: string[]) => {
+    this.node.tags = tags;
+  };
 
+  onSubmit = () => {
+    this.node.id = v4();
+    this.treeSvc.addNode(this.node);
+    console.log(this.node.tags);
+    this.node = {
+      name: '',
+    };
+    this.tagsComponent.clearSelections();
+    this.submitted.emit(true);
+  };
 }

--- a/src/app/components/food-counter/food-counter.component.ts
+++ b/src/app/components/food-counter/food-counter.component.ts
@@ -13,17 +13,20 @@ export class FoodCounterComponent implements OnInit {
   constructor(private treeSvc: TreeService) {
     this.treeSvc.getNodes().subscribe((res) => {
       this.count = 0;
-      this._recursivelyCountNodes(res.nodes)
+      this._recursivelyCountNodes(res.nodes, []);
     });
   }
 
   ngOnInit(): void {}
 
-  /* Count number of nodes that don't start with "Tag: " */
-  private _recursivelyCountNodes = (nodes: Node[]) => {
+  /* Count number of nodes that aren't tags */
+  private _recursivelyCountNodes = (nodes: Node[], ids: Node['id'][]) => {
     nodes?.forEach((node: Node) => {
-      !node.isTag && this.count++;
-      this._recursivelyCountNodes(node.children);
+      if (!node.isTag && !ids.includes(node.id)) {
+        ids.push(node.id);
+        this.count++;
+      }
+      this._recursivelyCountNodes(node.children, ids);
     });
   };
 }

--- a/src/app/components/multiple-autocomplete/multiple-autocomplete.component.ts
+++ b/src/app/components/multiple-autocomplete/multiple-autocomplete.component.ts
@@ -22,7 +22,7 @@ import {
 } from 'rxjs/operators';
 import { TreeService } from 'src/app/services/tree.service';
 import { Node } from '../../interfaces/interfaces';
-import { forEach } from 'lodash';
+import { forEach, filter } from 'lodash';
 
 // https://material.angular.io/components/chips/overview
 // debounce ref: https://stackoverflow.com/questions/41308826/angular-2-debounce-ngmodelchange/52977862#52977862
@@ -44,6 +44,7 @@ export class MultipleAutocompleteComponent {
   @Input() placeholder: string;
   @Input() width: string;
   @Input() callback: () => void;
+  @Input() tagsOnly: boolean;
   @Output() values: EventEmitter<string[]> = new EventEmitter();
 
   @ViewChild('searchInput') searchInput: ElementRef<HTMLInputElement>;
@@ -69,7 +70,13 @@ export class MultipleAutocompleteComponent {
   }
 
   getNames = (node: Node) => {
-    this.allOptions.push(node.name);
+    if (this.tagsOnly) {
+      if (node.isTag) {
+        this.allOptions.push(node.name);
+      }
+    } else {
+      this.allOptions.push(node.name);
+    }
     forEach(node.children, (child) => {
       this.getNames(child);
     });

--- a/src/app/components/multiple-autocomplete/multiple-autocomplete.component.ts
+++ b/src/app/components/multiple-autocomplete/multiple-autocomplete.component.ts
@@ -78,7 +78,9 @@ export class MultipleAutocompleteComponent {
   /* Runs when the model changes (ngModelChange)
    */
   onChange = () => {
-    this.callback();
+    if (this.callback) {
+      this.callback();
+    }
   };
 
   add = (event: MatChipInputEvent): void => {
@@ -106,7 +108,9 @@ export class MultipleAutocompleteComponent {
       this.selectedValues.splice(index, 1);
     }
     this.values.emit(this.selectedValues);
-    this.callback();
+    if (this.callback) {
+      this.callback();
+    }
   };
 
   selected = (event: MatAutocompleteSelectedEvent): void => {

--- a/src/app/components/tree/tree.component.ts
+++ b/src/app/components/tree/tree.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, ViewChild } from '@angular/core';
 import { Router } from '@angular/router';
-import { IActionMapping } from '@circlon/angular-tree-component';
+import { IActionMapping, TREE_ACTIONS } from '@circlon/angular-tree-component';
 import { SharedTreeDataService } from 'src/app/services/shared-tree-data.service';
 import { TreeService } from 'src/app/services/tree.service';
 import { Node, Tree } from '../../interfaces/interfaces';
@@ -24,6 +24,11 @@ export class TreeComponent implements OnInit {
         this.clickedNode = node;
         this.router.navigateByUrl(`/view/${node.id}`);
       },
+      drop: (tree, node, $event, { from, to }) => {
+        TREE_ACTIONS.MOVE_NODE(tree, node, $event, { from, to });
+        console.log(this.nodes);
+        this.treeSvc.setNodes(this.nodes);
+      },
     },
   };
 
@@ -39,7 +44,7 @@ export class TreeComponent implements OnInit {
   constructor(
     private treeSvc: TreeService,
     private sharedDataSvc: SharedTreeDataService,
-    private router: Router,
+    private router: Router
   ) {
     this.treeSvc.getNodes().subscribe((res) => {
       this.nodes = res.nodes;
@@ -48,7 +53,6 @@ export class TreeComponent implements OnInit {
 
   ngOnInit(): void {
     this.sharedDataSvc.tree = this.tree;
-
   }
 
   // ref: https://stackoverflow.com/a/39569933/9931154

--- a/src/app/components/tree/tree.component.ts
+++ b/src/app/components/tree/tree.component.ts
@@ -26,7 +26,6 @@ export class TreeComponent implements OnInit {
       },
       drop: (tree, node, $event, { from, to }) => {
         TREE_ACTIONS.MOVE_NODE(tree, node, $event, { from, to });
-        console.log(this.nodes);
         this.treeSvc.setNodes(this.nodes);
       },
     },

--- a/src/app/components/tree/tree.component.ts
+++ b/src/app/components/tree/tree.component.ts
@@ -30,7 +30,10 @@ export class TreeComponent implements OnInit, AfterViewInit {
         this.router.navigateByUrl(`/view/${node.id}`);
       },
       drop: (tree, node, $event, { from, to }) => {
-        if (!map(to.parent.children, 'id').includes(from.data.id)) {
+        if (
+          !map(to.parent.children, 'id').includes(from.data.id) &&
+          to.parent.data.isTag
+        ) {
           TREE_ACTIONS.MOVE_NODE(tree, node, $event, { from, to });
           this.treeSvc.setNodes(this.nodes);
         }

--- a/src/app/components/tree/tree.component.ts
+++ b/src/app/components/tree/tree.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ViewChild } from '@angular/core';
+import { AfterViewInit, Component, OnInit, ViewChild } from '@angular/core';
 import { Router } from '@angular/router';
 import {
   IActionMapping,
@@ -16,7 +16,7 @@ import { Node, Tree } from '../../interfaces/interfaces';
   templateUrl: './tree.component.html',
   styleUrls: ['./tree.component.scss'],
 })
-export class TreeComponent implements OnInit {
+export class TreeComponent implements OnInit, AfterViewInit {
   nodes: Node[] = [];
   clickedNode: Node;
   // get handle an tree template variable
@@ -57,7 +57,9 @@ export class TreeComponent implements OnInit {
     });
   }
 
-  ngOnInit(): void {
+  ngOnInit(): void {}
+
+  ngAfterViewInit(): void {
     this.sharedDataSvc.tree = this.tree;
   }
 

--- a/src/app/components/tree/tree.component.ts
+++ b/src/app/components/tree/tree.component.ts
@@ -1,6 +1,11 @@
 import { Component, OnInit, ViewChild } from '@angular/core';
 import { Router } from '@angular/router';
-import { IActionMapping, TREE_ACTIONS } from '@circlon/angular-tree-component';
+import {
+  IActionMapping,
+  TREE_ACTIONS,
+  TreeNode,
+} from '@circlon/angular-tree-component';
+import { map } from 'lodash';
 import { SharedTreeDataService } from 'src/app/services/shared-tree-data.service';
 import { TreeService } from 'src/app/services/tree.service';
 import { Node, Tree } from '../../interfaces/interfaces';
@@ -25,8 +30,10 @@ export class TreeComponent implements OnInit {
         this.router.navigateByUrl(`/view/${node.id}`);
       },
       drop: (tree, node, $event, { from, to }) => {
-        TREE_ACTIONS.MOVE_NODE(tree, node, $event, { from, to });
-        this.treeSvc.setNodes(this.nodes);
+        if (!map(to.parent.children, 'id').includes(from.data.id)) {
+          TREE_ACTIONS.MOVE_NODE(tree, node, $event, { from, to });
+          this.treeSvc.setNodes(this.nodes);
+        }
       },
     },
   };

--- a/src/app/services/tree.service.ts
+++ b/src/app/services/tree.service.ts
@@ -52,7 +52,9 @@ export class TreeService {
   }
 
   getUserDoc = () => {
-    const userDoc = this.db.collection('users').doc<{ nodes: Node[] }>(userName);
+    const userDoc = this.db
+      .collection('users')
+      .doc<{ nodes: Node[] }>(userName);
     this.isLoading = false;
     return userDoc;
   };
@@ -87,5 +89,26 @@ export class TreeService {
     forEach(currentNode.children, (childNode) => {
       this.searchTree(tag, nodeToAdd, childNode);
     });
+  };
+
+  hasTag = (tag: string, node?: Node): boolean => {
+    if (node) {
+      if (tag === node.name) {
+        return true;
+      }
+      forEach(node.children, (childNode) => {
+        return this.hasTag(tag, childNode);
+      });
+      return false;
+    } else {
+      forEach(this.nodes, (node) => {
+        return this.hasTag(tag, node);
+      });
+    }
+  };
+
+  setNodes = (nodes: Node[]) => {
+    this.nodes = nodes;
+    this.getUserDoc().set({ nodes: this.nodes });
   };
 }

--- a/src/app/services/tree.service.ts
+++ b/src/app/services/tree.service.ts
@@ -3,6 +3,7 @@ import { AngularFirestore } from '@angular/fire/firestore';
 import { Node } from '../interfaces/interfaces';
 import { forEach } from 'lodash';
 import { TreeNode } from '@circlon/angular-tree-component';
+import { map } from 'lodash';
 
 const userName = 'user1';
 
@@ -71,14 +72,17 @@ export class TreeService {
           this.searchTree(tag, node, topNode);
         });
       });
-    } else {
+    } else if (!this._getNames(this.nodes).includes(node.name)) {
       this.nodes.push(node);
     }
     this.getUserDoc().set({ nodes: this.nodes });
   };
 
   searchTree = (tag: string, nodeToAdd: Node, currentNode: Node) => {
-    if (currentNode.name === tag) {
+    if (
+      currentNode.name === tag &&
+      !this._getNames(currentNode.children).includes(nodeToAdd.name)
+    ) {
       if (currentNode.children) {
         currentNode.children.push(nodeToAdd as TreeNode);
       } else {
@@ -116,5 +120,9 @@ export class TreeService {
   setNodes = (nodes: Node[]) => {
     this.nodes = nodes;
     this.getUserDoc().set({ nodes: this.nodes });
+  };
+
+  _getNames = (nodes: Node[]): string[] => {
+    return map(nodes, 'name');
   };
 }

--- a/src/app/services/tree.service.ts
+++ b/src/app/services/tree.service.ts
@@ -92,19 +92,25 @@ export class TreeService {
   };
 
   hasTag = (tag: string, node?: Node): boolean => {
+    let tagFound = false;
     if (node) {
       if (tag === node.name) {
         return true;
       }
       forEach(node.children, (childNode) => {
-        return this.hasTag(tag, childNode);
+        if (this.hasTag(tag, childNode)) {
+          tagFound = true;
+        }
       });
-      return false;
+      // Initial Call
     } else {
       forEach(this.nodes, (node) => {
-        return this.hasTag(tag, node);
+        if (this.hasTag(tag, node)) {
+          tagFound = true;
+        }
       });
     }
+    return tagFound;
   };
 
   setNodes = (nodes: Node[]) => {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -15,6 +15,16 @@ body {
   overflow: hidden !important;
 }
 
+div.mat-chip-list-wrapper {
+  flex-wrap: nowrap;
+  overflow-x: auto;
+  white-space: nowrap;
+}
+
 button:focus {
   outline: none !important;
+}
+
+.form {
+  padding-left: 0.5vw;
 }


### PR DESCRIPTION
I ended up doing a bit more on this brach than I originally intended for this feature. It:

- Allows you to submit a new tag
  - Test by using the add button and the tag tab
- Allows you to make a new tag when adding a food
  - Test by using the add button and the food tab. Then enter a new tag in the `Tags` box and click ENTER. Then Submit and there should be a new Tag with the new food as a child. The old functionality of adding a new food to an existing tag should still work.
- Submits data to the database when a node is dragged and dropped
  - Test by moving a node to a new place. Then add a new food. The moved node will stay where you moved it.
- No longer adds duplicates to the same place in the tree
  - Tagging a new food with the same tag twice should only add it once.
  - Adding a food that's already in the tree and tagged with the same tags won't be added.
  - Dragging and dropping a food to a place where it's already tagged will not move it
- No longer double counts a food if it has multiple tags
  - Test by adding a food with multiple tags. The counter should only go up by 1
- Fixes a bug where the callback in `multiple-autocomplete` is called but not defined
- Filters the tag autocomplete when adding so only tag names appear as options
  - Test by adding a new food. When typing in the `Tags` field, only tags should appear
- Disables dropping into food nodes
  - Test by trying to drop a node into a food. It shouldn't move
  - Then drag a node into a tag. It should move.
- Fixes a bug where adding too many tags for a food makes the submit button scroll off the screen
  - I fixed this by making the tags text field horizontally scrollable
  - Test by adding a bunch of tags to the `Tags` text field when adding a food

Sorry that this ended up being kind of complicated. Let me know if you're confused by anything!
